### PR TITLE
Attach callback to spawn exit

### DIFF
--- a/terminate.js
+++ b/terminate.js
@@ -20,10 +20,12 @@ module.exports = function terminate(pid, callback) {
   psTree(pid, function (err, children) {
     console.log("Children:", children.length);
     cp.spawn('kill', ['-9'].concat(children.map(function (p) { return p.PID })))
-    if(callback && typeof callback === 'function') {
-      callback(err, true);
-    } else { // do nothing
-      console.log(children.length + " Processes Terminated!");
-    }
+      .on('exit', function() {
+        if(callback && typeof callback === 'function') {
+          callback(err, true);
+        } else { // do nothing
+          console.log(children.length + " Processes Terminated!");
+        }
+      });
   });
 };


### PR DESCRIPTION
This updates the callback to be called after the `kill` command actually completes
