### PR TITLE
Remove console.logs, bail early on error

### DIFF
--- a/terminate.js
+++ b/terminate.js
@@ -16,15 +16,15 @@ module.exports = function terminate(pid, callback) {
   if(!pid) {
     throw new Error("No pid supplied to Terminate!")
   }
-  var signal = 'SIGKILL';
   psTree(pid, function (err, children) {
-    console.log("Children:", children.length);
+    if(err) {
+      return callback(err, false);
+    }
+
     cp.spawn('kill', ['-9'].concat(children.map(function (p) { return p.PID })))
       .on('exit', function() {
         if(callback && typeof callback === 'function') {
-          callback(err, true);
-        } else { // do nothing
-          console.log(children.length + " Processes Terminated!");
+          callback(null, true);
         }
       });
   });


### PR DESCRIPTION
This removes the debugging `console.log`s from #5.
This also removes an unused variable and bails early if there was an error getting child processes rather than trying to `spawn` regardless.
