### PR TITLE
feat: expose promise-based interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@ const terminate = require('terminate');
 
 terminate(process.pid, function (err) {
   if (err) { // you will get an error if you did not supply a valid process.pid
-    console.log("Oopsy: " + err); // handle errors in your preferred way.
+    console.log('Oopsy:', err); // handle errors in your preferred way.
   }
   else {
     console.log('done'); // terminating the Processes succeeded.
+    // NOTE: The above won't be run in this example as the process itself will be killed before.
   }
 });
 ```
@@ -40,6 +41,23 @@ terminate(process.pid, function (err) {
 #### Usage
 
 All the available parameters and their descriptions are viewable in the TypeScript definition file: [**`index.d.ts`**](./index.d.ts#L71).
+
+#### Promise API
+
+If you are **using Node.js 8+**, you can load the Promise version importing the module `terminate/promise.js` like this:
+
+```js
+const terminate = require('terminate/promise');
+
+(async () => {
+  try {
+    await terminate(process.pid);
+    console.log('done');
+  } catch (err) {
+    console.log('Oopsy:', err);
+  }
+})();
+```
 
 <br />
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -52,7 +52,7 @@ declare module 'terminate' {
    * @param pid - the Process ID you want to terminate.
    * @param signal - the signal to kill the processes with. Defaults to `"SIGKILL"`
    * if it's empty or not defined.
-   * @param opts - options to object.
+   * @param opts - options object.
    */
   export default function terminate(pid: number, signal: string, opts: TerminateOptions): void;
 
@@ -64,7 +64,7 @@ declare module 'terminate' {
    * @param pid - the Process ID you want to terminate.
    * @param signal - the signal to kill the processes with. Defaults to `"SIGKILL"`
    * if it's empty or not defined.
-   * @param opts - options to object.
+   * @param opts - options object.
    * @param callback - if you want to know once the procesess have been terminated,
    * supply a callback.
    */
@@ -90,7 +90,7 @@ declare module 'terminate' {
    * @param pid - the Process ID you want to terminate.
    * @param signal - the signal to kill the processes with. Defaults to `"SIGKILL"`
    * if it's empty or not defined.
-   * @param opts - options to object.
+   * @param opts - options object.
    * @param callback - if you want to know once the procesess have been terminated,
    * supply a callback.
    */
@@ -102,7 +102,7 @@ declare module 'terminate' {
    * them down too, so you don't have to worry about lingering processes.
    *
    * @param pid - the Process ID you want to terminate.
-   * @param opts - options to object.
+   * @param opts - options object.
    */
   export default function terminate(pid: number, opts: TerminateOptions): void;
 

--- a/promise.d.ts
+++ b/promise.d.ts
@@ -1,0 +1,52 @@
+/// <reference path="index.d.ts"/>
+
+declare module 'terminate/promise' {
+  import type { TerminateOptions } from 'terminate'
+
+  /**
+   * `terminate` is an ultra-simple way to kill all the node processes
+   * by providing a process pid. It finds all child processes and shuts
+   * them down too, so you don't have to worry about lingering processes.
+   *
+   * @param pid - the Process ID you want to terminate.
+   * @throws {Error} - if something went wrong.
+   */
+  export default function terminate(pid: number): Promise<void>;
+
+  /**
+   * `terminate` is an ultra-simple way to kill all the node processes
+   * by providing a process pid. It finds all child processes and shuts
+   * them down too, so you don't have to worry about lingering processes.
+   *
+   * @param pid - the Process ID you want to terminate.
+   * @param signal - the signal to kill the processes with. Defaults to `"SIGKILL"`
+   * if it's empty or not defined.
+   * @param opts - options object.
+   * @throws {Error} - if something went wrong.
+   */
+  export default function terminate(pid: number, signal?: string, opts?: TerminateOptions): Promise<void>;
+
+  /**
+   * `terminate` is an ultra-simple way to kill all the node processes
+   * by providing a process pid. It finds all child processes and shuts
+   * them down too, so you don't have to worry about lingering processes.
+   *
+   * @param pid - the Process ID you want to terminate.
+   * @param signal - the signal to kill the processes with. Defaults to `"SIGKILL"`
+   * if it's empty or not defined.
+   * @param opts - options object.
+   * @throws {Error} - if something went wrong.
+   */
+  export default function terminate(pid: number, signal: string, opts?: TerminateOptions): Promise<void>;
+
+  /**
+   * `terminate` is an ultra-simple way to kill all the node processes
+   * by providing a process pid. It finds all child processes and shuts
+   * them down too, so you don't have to worry about lingering processes.
+   *
+   * @param pid - the Process ID you want to terminate.
+   * @param opts - options object.
+   * @throws {Error} - if something went wrong.
+   */
+  export default function terminate(pid: number, opts: TerminateOptions): Promise<void>;
+}

--- a/promise.js
+++ b/promise.js
@@ -1,0 +1,10 @@
+//
+// This module just need to expose a Promise interface of `terminate` using the
+// built-in `promisify` utility (see https://nodejs.org/api/util.html#util_util_promisify_original).
+// As the callback version follows the 'error-first' pattern, the Promise version
+// doesn't need to be tested. Is guaranteed that it will work as intended.
+//
+var util = require('util');
+var terminate = require('../terminate');
+
+module.exports = util.promisify(terminate);


### PR DESCRIPTION
closes #32

I know we can leave this to the user _but_ as the new `promise.js` file is pretty slim (yeah, I want to keep this lib as small as possible), and as the Promise-base interface is loaded on demand (via `require('terminate/promise')`), I don't see any cons on bundling it here.

![image](https://user-images.githubusercontent.com/13461315/149424063-3a262648-65fa-4d32-b326-425a47890212.png)

---

Maybe `require('terminate/promises')` would be better (like the native on `require('fs/promises')`)? Let me know.